### PR TITLE
Use clickhouse official docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM yandex/clickhouse-server:22.1.3.7
+FROM clickhouse/clickhouse-server:23.1.3.5

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dokku clickhouse [![Build Status](https://img.shields.io/github/actions/workflow/status/dokku/dokku-clickhouse/ci.yml?branch=master&style=flat-square "Build Status")](https://github.com/dokku/dokku-clickhouse/actions/workflows/ci.yml?query=branch%3Amaster) [![IRC Network](https://img.shields.io/badge/irc-libera-blue.svg?style=flat-square "IRC Libera")](https://webchat.libera.chat/?channels=dokku)
 
-Official clickhouse plugin for dokku. Currently defaults to installing [yandex/clickhouse-server 22.1.3.7](https://hub.docker.com/r/yandex/clickhouse-server/).
+Official clickhouse plugin for dokku. Currently defaults to installing [clickhouse/clickhouse-server 23.1.3.5](https://hub.docker.com/r/clickhouse/clickhouse-server/).
 
 ## Sponsors
 
@@ -80,10 +80,10 @@ Create a clickhouse service named lollipop:
 dokku clickhouse:create lollipop
 ```
 
-You can also specify the image and image version to use for the service. It *must* be compatible with the yandex/clickhouse-server image.
+You can also specify the image and image version to use for the service. It *must* be compatible with the clickhouse/clickhouse-server image.
 
 ```shell
-export CLICKHOUSE_IMAGE="yandex/clickhouse-server"
+export CLICKHOUSE_IMAGE="clickhouse/clickhouse-server"
 export CLICKHOUSE_IMAGE_VERSION="${PLUGIN_IMAGE_VERSION}"
 dokku clickhouse:create lollipop
 ```


### PR DESCRIPTION
Hello there :wave: 

When this plugin was created, there weren't any official clickhouse docker image. Now the `yandex` image is not updated anymore so is lagging behind (last version of the `yandex` repository is [21.3.20](https://hub.docker.com/r/yandex/clickhouse-server/tags))

WDYT?