### PR TITLE
feat: copy configuration from plugin image

### DIFF
--- a/functions
+++ b/functions
@@ -49,9 +49,9 @@ service_create() {
   mkdir -p "$SERVICE_ROOT/$PLUGIN_CONFIG_SUFFIX/users.d/" || dokku_log_fail "Unable to create users.d directory"
   touch "$LINKS_FILE"
 
-  curl -sSL "https://raw.githubusercontent.com/ClickHouse/ClickHouse/v${PLUGIN_IMAGE_VERSION}-stable/programs/server/config.xml" >"$SERVICE_ROOT/$PLUGIN_CONFIG_SUFFIX/config.xml" || dokku_log_fail "Unable to download the default config.xml to the config directory"
-  curl -sSL "https://raw.githubusercontent.com/ClickHouse/ClickHouse/v${PLUGIN_IMAGE_VERSION}-stable/docker/server/docker_related_config.xml" >"$SERVICE_ROOT/$PLUGIN_CONFIG_SUFFIX/config.d/docker_related_config.xml" || dokku_log_fail "Unable to download the extra docker config (docker_related_config.xml) to the config directory"
-  curl -sSL "https://raw.githubusercontent.com/ClickHouse/ClickHouse/v${PLUGIN_IMAGE_VERSION}-stable/programs/server/users.xml" >"$SERVICE_ROOT/$PLUGIN_CONFIG_SUFFIX/users.xml" || dokku_log_fail "Unable to download the default users.xml to the config directory"
+  "$DOCKER_BIN" run --rm --entrypoint cat "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" /etc/clickhouse-server/config.xml >"$SERVICE_ROOT/$PLUGIN_CONFIG_SUFFIX/config.xml" || dokku_log_fail "Unable to get the default config.xml from the image to the config directory"
+  "$DOCKER_BIN" run --rm --entrypoint cat "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" /etc/clickhouse-server/config.d/docker_related_config.xml >"$SERVICE_ROOT/$PLUGIN_CONFIG_SUFFIX/config.d/docker_related_config.xml" || dokku_log_fail "Unable to get the extra docker config (docker_related_config.xml) from the image to the config directory"
+  "$DOCKER_BIN" run --rm --entrypoint cat "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" /etc/clickhouse-server/users.xml >"$SERVICE_ROOT/$PLUGIN_CONFIG_SUFFIX/users.xml" || dokku_log_fail "Unable to get the default users.xml from the image to the config directory"
 
   cp "/var/lib/dokku/plugins/available/$PLUGIN_COMMAND_PREFIX/system_log_ttl_config.xml" "$SERVICE_ROOT/$PLUGIN_CONFIG_SUFFIX/config.d/system_log_ttl_config.xml" || dokku_log_fail "Unable to copy the default system log TTL config (system_log_ttl_config.xml) to the config directory"
 


### PR DESCRIPTION
As discussed in #66 reading the configuration from the GitHub page can lead to unexpected results. In the current implementation some tags like `latest` result in error because they don't have the expected `-stable` suffix. Luckily, these files can be read from the image.